### PR TITLE
Update reference to type `SchemaGeneratorConfiguration` (typo)

### DIFF
--- a/_docs/release-notes/rn-json-schema-generation.md
+++ b/_docs/release-notes/rn-json-schema-generation.md
@@ -56,7 +56,7 @@ Add .Net 9.0 support.
 [#768](https://github.com/gregsdennis/json-everything/issues/768) - Added two ways to allow external references.  Thanks to [@luisjones](https://github.com/luisjones) for suggesting the idea.
 
 - Added `[Id]` attribute
-- Added `SchemaGenerationConfiguration.ExternalReferences`
+- Added `SchemaGeneratorConfiguration.ExternalReferences`
 
 # [4.4.0](https://github.com/gregsdennis/json-everything/pull/770) {#release-schemagen-4.4.0}
 

--- a/_docs/schema/schemagen/schema-generation.md
+++ b/_docs/schema/schemagen/schema-generation.md
@@ -181,7 +181,7 @@ Another way to apply references is through the configuration's `ExternalReferenc
 {: .prompt-warning }
 
 ```c#
-var config = new SchemaGenerationConfiguration
+var config = new SchemaGeneratorConfiguration
 {
     ExternalReferences = 
     {


### PR DESCRIPTION
The sample code of ExternalReferences uses the non-existent type `SchemaGenerationConfiguration` instead of the available `SchemaGeneratorConfiguration`

There are three additional mentions in the past release notes which I didn't update.

Cheers, JoKi 