### PR TITLE
docs(schema/serialization): change JsonSchemaType to SchemaValueType

### DIFF
--- a/_docs/schema/serialization.md
+++ b/_docs/schema/serialization.md
@@ -110,10 +110,10 @@ public static class Schemas
 {
     public static JsonSchema MyModelSchema =
         new JsonSchemaBuilder()
-            .Type(JsonSchemaType.Object)
+            .Type(SchemaValueType.Object)
             .Properties(
                 (nameof(MyModel.Foo), new JsonSchemaBuilder()
-                    .Type(JsonSchemaType.String)
+                    .Type(SchemaValueType.String)
                     .MinLength(10)
                     .MaxLength(50)
                 )


### PR DESCRIPTION
have noticed the `JsonSchemaBuilder` uses `SchemaValueType` instead of `JsonSchemaType` for the Type Extension function while reading docs so i updated it